### PR TITLE
Don't throw errors on 404s

### DIFF
--- a/common/error_routes.py
+++ b/common/error_routes.py
@@ -5,7 +5,7 @@ from assess.authentication.auth import auth_protect
 
 
 def not_found(error):
-    current_app.logger.error(error)
+    current_app.logger.debug(error)
 
     if request.host == current_app.config['ASSESS_HOST']:
         @login_requested


### PR DESCRIPTION
Error log messages get raised in Sentry as exceptions and trigger alerts. This is not needed for 404s in most cases.