### PR TITLE
FSPT-190 Get the account store URI from the parameter store

### DIFF
--- a/copilot/fsd-pre-award-frontend/manifest.yml
+++ b/copilot/fsd-pre-award-frontend/manifest.yml
@@ -47,7 +47,6 @@ network:
 #
 # Pass environment variables as key value pairs.
 variables:
-  ACCOUNT_STORE_API_HOST: "http://fsd-account-store:8080"
   APPLY_HOST: "frontend.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk"
   APPLICANT_FRONTEND_HOST: "https://frontend.${COPILOT_ENVIRONMENT_NAME}.access-funding.test.levellingup.gov.uk"  # TODO: remove me when all frontends combined
   COOKIE_DOMAIN: ".test.levellingup.gov.uk"
@@ -60,6 +59,7 @@ variables:
     from_cfn: ${COPILOT_APPLICATION_NAME}-${COPILOT_ENVIRONMENT_NAME}-FormUploadsBucket
 
 secrets:
+  ACCOUNT_STORE_API_HOST: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/ACCOUNT_STORE_API_HOST
   FUND_STORE_API_HOST: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/FUND_STORE_API_HOST
   APPLICATION_STORE_API_HOST: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/APPLICATION_STORE_API_HOST
   RSA256_PUBLIC_KEY_BASE64: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/RSA256_PUBLIC_KEY_BASE64


### PR DESCRIPTION
Fetching the account store uri from the parameter store will allow us to switch from using the existing fixed account store microservice and point it to the new combined pre-award-stores when its ready.