### PR TITLE
Pull in language selector from utils and fix for host matching

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,7 +6,7 @@ from flask_babel import Babel, gettext, pgettext
 from flask_compress import Compress
 from flask_talisman import Talisman
 from flask_wtf.csrf import CSRFProtect
-from fsd_utils import LanguageSelector, init_sentry
+from fsd_utils import init_sentry
 from fsd_utils.healthchecks.checkers import FlaskRunningChecker
 from fsd_utils.healthchecks.healthcheck import Healthcheck
 from fsd_utils.locale_selector.get_lang import get_lang
@@ -40,6 +40,7 @@ from assess.shared.filters import (
     slash_separated_day_month_year,
     utc_to_bst,
 )
+from common.locale_selector.set_lang import LanguageSelector
 from config import Config
 
 

--- a/apply/default/account_routes.py
+++ b/apply/default/account_routes.py
@@ -2,8 +2,6 @@ import requests
 from flask import current_app, g, make_response, redirect, render_template, request, url_for
 from flask_babel import force_locale
 from fsd_utils.authentication.decorators import login_required
-from fsd_utils.locale_selector.get_lang import get_lang
-from fsd_utils.locale_selector.set_lang import LanguageSelector
 
 from apply.default.data import (
     RoundStatus,
@@ -15,6 +13,8 @@ from apply.default.data import (
 from apply.helpers import get_fund, get_fund_and_round, get_ttl_hash
 from apply.models.application_summary import ApplicationSummary
 from common.blueprints import Blueprint
+from common.locale_selector.get_lang import get_lang
+from common.locale_selector.set_lang import LanguageSelector
 from config import Config
 
 account_bp = Blueprint("account_routes", __name__, template_folder="templates")

--- a/apply/default/application_routes.py
+++ b/apply/default/application_routes.py
@@ -7,7 +7,6 @@ from flask_babel import force_locale, gettext
 from flask_wtf import FlaskForm
 from fsd_utils import Decision
 from fsd_utils.authentication.decorators import login_required
-from fsd_utils.locale_selector.set_lang import LanguageSelector
 from fsd_utils.simple_utils.date_utils import (
     current_datetime_after_given_iso_string,
 )
@@ -45,6 +44,7 @@ from apply.helpers import (
 )
 from apply.models.statuses import get_formatted
 from common.blueprints import Blueprint
+from common.locale_selector.set_lang import LanguageSelector
 from config import Config
 
 application_bp = Blueprint("application_routes", __name__, template_folder="templates")

--- a/apply/default/content_routes.py
+++ b/apply/default/content_routes.py
@@ -1,12 +1,12 @@
 from flask import abort, current_app, redirect, render_template, request, url_for
 from flask_babel import gettext
 from fsd_utils.authentication.decorators import login_requested
-from fsd_utils.locale_selector.get_lang import get_lang
 from jinja2.exceptions import TemplateNotFound
 
 from apply.helpers import find_fund_and_round_in_request, find_round_in_request, get_fund_and_round
 from apply.models.fund import Fund
 from common.blueprints import Blueprint
+from common.locale_selector.get_lang import get_lang
 from config import Config
 
 content_bp = Blueprint("content_routes", __name__, template_folder="templates")

--- a/apply/default/data.py
+++ b/apply/default/data.py
@@ -8,7 +8,6 @@ from urllib.parse import urlencode
 
 import requests
 from flask import abort, current_app
-from fsd_utils.locale_selector.get_lang import get_lang
 from fsd_utils.simple_utils.date_utils import (
     current_datetime_after_given_iso_string,
     current_datetime_before_given_iso_string,
@@ -22,6 +21,7 @@ from apply.models.feedback import EndOfApplicationSurveyData, FeedbackSubmission
 from apply.models.fund import Fund
 from apply.models.research import ResearchSurveyData
 from apply.models.round import Round
+from common.locale_selector.get_lang import get_lang
 from config import Config
 
 

--- a/apply/helpers.py
+++ b/apply/helpers.py
@@ -4,7 +4,6 @@ from functools import lru_cache
 
 import requests
 from flask import current_app, request
-from fsd_utils.locale_selector.get_lang import get_lang
 
 from apply.default.data import (
     get_all_funds,
@@ -21,6 +20,7 @@ from apply.default.data import (
 )
 from apply.models.fund import Fund
 from apply.models.round import Round
+from common.locale_selector.get_lang import get_lang
 from config import Config
 
 

--- a/assess/services/data_services.py
+++ b/assess/services/data_services.py
@@ -5,7 +5,6 @@ from urllib.parse import urlencode
 
 import requests
 from flask import abort, current_app
-from fsd_utils.locale_selector.get_lang import get_lang
 
 from assess.scoring.models.score import Score
 from assess.services.models.application import Application
@@ -20,6 +19,7 @@ from assess.tagging.models.tag import AssociatedTag, Tag, TagType
 from assess.themes.deprecated_theme_mapper import (
     map_application_with_sub_criteria_themes_fields,
 )
+from common.locale_selector.get_lang import get_lang
 from config import Config
 
 

--- a/authenticator/app.py
+++ b/authenticator/app.py
@@ -12,12 +12,12 @@ from frontend.magic_links.filters import datetime_format
 from fsd_utils import LanguageSelector, init_sentry
 from fsd_utils.healthchecks.checkers import FlaskRunningChecker, RedisChecker
 from fsd_utils.healthchecks.healthcheck import Healthcheck
-from fsd_utils.locale_selector.get_lang import get_lang
 from fsd_utils.logging import logging
 from fsd_utils.services.aws_extended_client import SQSExtendedClient
 from jinja2 import ChoiceLoader, PackageLoader, PrefixLoader
 from models.fund import FundMethods
 
+from common.locale_selector.get_lang import get_lang
 from config import Config
 
 redis_mlinks = FlaskRedis(config_prefix="REDIS_MLINKS")

--- a/authenticator/models/data.py
+++ b/authenticator/models/data.py
@@ -4,8 +4,8 @@ import urllib.parse
 
 import requests
 from flask import current_app
-from fsd_utils.locale_selector.get_lang import get_lang
 
+from common.locale_selector.get_lang import get_lang
 from config import Config
 from models.round import Round
 

--- a/authenticator/models/fund.py
+++ b/authenticator/models/fund.py
@@ -2,8 +2,8 @@ from dataclasses import dataclass
 from typing import List
 
 from flask import request
-from fsd_utils.locale_selector.get_lang import get_lang
 
+from common.locale_selector.get_lang import get_lang
 from config import Config
 from models.data import get_data
 from models.round import Round

--- a/common/locale_selector/__init__.py
+++ b/common/locale_selector/__init__.py
@@ -1,0 +1,2 @@
+from . import get_lang  # noqa
+from . import set_lang  # noqa

--- a/common/locale_selector/get_lang.py
+++ b/common/locale_selector/get_lang.py
@@ -1,0 +1,28 @@
+from babel import negotiate_locale
+from flask import request
+from fsd_utils import CommonConfig
+
+
+def get_lang():
+    # get lang if lang query arg is set
+    language_from_query_args = request.args.get("lang")
+    if language_from_query_args:
+        if language_from_query_args not in ["cy", "en"]:
+            return "en"
+        return language_from_query_args
+
+    # get locale from cookie if set
+    locale_from_cookie = request.cookies.get(CommonConfig.FSD_LANG_COOKIE_NAME)
+    if locale_from_cookie:
+        if locale_from_cookie not in ["cy", "en"]:
+            return "en"
+        return locale_from_cookie
+
+    # otherwise guess preference based on user accept header
+    preferred = [accept_language.replace("-", "_") for accept_language in request.accept_languages.values()]
+    negotiated_locale = negotiate_locale(preferred, ["en", "cy"])
+    if negotiated_locale:
+        return negotiated_locale
+
+    # default is to return english
+    return "en"

--- a/common/locale_selector/set_lang.py
+++ b/common/locale_selector/set_lang.py
@@ -1,0 +1,36 @@
+from flask import Response, current_app, make_response, redirect, request
+from fsd_utils import CommonConfig
+
+
+class LanguageSelector:
+    @staticmethod
+    def get_cookie_domain(cookie_domain):
+        if not cookie_domain:
+            return None
+        else:
+            return cookie_domain
+
+    @staticmethod
+    def set_language_cookie(locale: str, response: Response):
+        response.set_cookie(
+            CommonConfig.FSD_LANG_COOKIE_NAME,
+            locale,
+            domain=LanguageSelector.get_cookie_domain(current_app.config["COOKIE_DOMAIN"]),
+            max_age=86400 * 30,  # 30 days
+        )
+
+    def __init__(self, app):
+        self.flask_app = app
+
+        # `host_from_current_request` is plumbed up in app.py
+        self.flask_app.add_url_rule(
+            "/language/<locale>", view_func=self.select_language, host="<host_from_current_request>"
+        )
+
+    @staticmethod
+    def select_language(locale):
+        # TODO: Perform additional validation on referrer
+        response = make_response(redirect(request.referrer or "/", 302))
+        LanguageSelector.set_language_cookie(locale, response)
+
+        return response

--- a/tests/common_tests/locale_selector_tests/test_get_lang.py
+++ b/tests/common_tests/locale_selector_tests/test_get_lang.py
@@ -1,0 +1,39 @@
+from common.locale_selector.get_lang import get_lang
+
+
+class TestGetLang:
+    def test_get_lang_query_arg_valid(self, app):
+        with app.test_client() as flask_test_client:
+            with flask_test_client.application.test_request_context("/?lang=cy"):
+                assert get_lang() == "cy"
+
+    def test_get_lang_query_arg_invalid(self, app):
+        with app.test_client() as flask_test_client:
+            with flask_test_client.application.test_request_context("/?lang=fr"):
+                assert get_lang() == "en"
+
+    def test_get_lang_cookie_preference(self, app):
+        with app.test_client() as flask_test_client:
+            with flask_test_client.application.test_request_context("/", headers={"Cookie": "language=cy"}):
+                assert get_lang() == "cy"
+
+    def test_get_lang_cookie_preference_for_non_en_cy_language(self, app):
+        with app.test_client() as flask_test_client:
+            with flask_test_client.application.test_request_context("/", headers={"Cookie": "language=de"}):
+                assert get_lang() == "en"
+
+    def test_get_lang_accept_language_preference_en(self, app):
+        with app.test_client() as flask_test_client:
+            with flask_test_client.application.test_request_context(
+                "/",
+                headers={"Accept-Language": "en,en-GB;q=0.9,cy;q=0.8,en-US;q=0.7"},
+            ):
+                assert get_lang() == "en"
+
+    def test_get_lang_accept_language_preference_cy(self, app):
+        with app.test_client() as flask_test_client:
+            with flask_test_client.application.test_request_context(
+                "/",
+                headers={"Accept-Language": "cy,en;q=0.9,en-GB;q=0.8,en-US;q=0.7"},  # noqa: E501
+            ):
+                assert get_lang() == "cy"

--- a/tests/common_tests/locale_selector_tests/test_set_lang.py
+++ b/tests/common_tests/locale_selector_tests/test_set_lang.py
@@ -1,0 +1,15 @@
+from unittest.mock import ANY, Mock
+
+from common.locale_selector.set_lang import LanguageSelector
+
+
+def test_set_lang(app):
+    mock_app = Mock()
+    set_lang = LanguageSelector(mock_app)
+    mock_app.add_url_rule.assert_called_with("/language/<locale>", view_func=ANY, host=ANY)
+    with app.test_client() as flask_test_client:
+        with flask_test_client.application.test_request_context():
+            response = set_lang.select_language("cy")
+            response_cookie = response.headers.get("Set-Cookie")
+            assert response_cookie is not None, "No cookie set for language"
+            assert response_cookie.split(";")[0] == ("language" + "=cy")


### PR DESCRIPTION
### Change description
Now that all of our frontends are coming in to one place, we don't need to use this from utils any more.

This pulls it into the pre-award-frontend app, and changes LanguageSelector to register the route against all hosts.

This fixes a bug where the `url_for` on `select_language` was resolving to an invalid URL, preventing users from changing language to Welsh on eg COF.
