### PR TITLE
Allow magic link assessment login in UAT environment

### DIFF
--- a/copilot/fsd-pre-award-frontend/manifest.yml
+++ b/copilot/fsd-pre-award-frontend/manifest.yml
@@ -135,6 +135,8 @@ environments:
         path: /healthcheck
         port: 8080
   uat:
+    variables:
+      ALLOW_ASSESSMENT_LOGIN_VIA_MAGIC_LINK: true
     http:
       target_container: nginx
       healthcheck:


### PR DESCRIPTION
We accidentally missed this environment variable for the UAT environment. end-to-end tests for assessment expect to (ab)use magic links to login as assessors, so this is needed.