### PR TITLE
Fix translations

### DIFF
--- a/app.py
+++ b/app.py
@@ -69,8 +69,7 @@ def create_app() -> Flask:  # noqa: C901
         toggle_client = create_toggles_client()
         load_toggles(Config.FEATURE_CONFIG, toggle_client)
 
-    babel = Babel(flask_app)
-    babel.locale_selector_func = get_lang
+    Babel(flask_app, locale_selector=get_lang)
     LanguageSelector(flask_app)
 
     # Bundle and compile assets


### PR DESCRIPTION
This needed to be updated when changing from Flask-Babel v2 to Flask-Babel v4, but I missed it. I missed it because half of our translations were working and half were not. Because, I think, some strings are translated in python and some are translated in jinja. The python ones were working, but the jinja ones seemed to not be.

From the changelog:

- Babel.locale_selector and Babel.timezone_selector no longer exist. They must be provided either when the Babel() object is created or when init_app() is called. This is to support having a single Babel object for multiple Flask apps (#107) as well as to simplify settings and multi-threaded state.

## Before
<img width="785" alt="image" src="https://github.com/user-attachments/assets/7bf344e4-f4e1-4944-8341-86d097734892" />


## After
<img width="942" alt="image" src="https://github.com/user-attachments/assets/a72764a0-0f96-431e-b6fd-70cae5027439" />